### PR TITLE
Fixing alpha animals warnings

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -110,7 +110,7 @@
 						<secondaryDamage>
 							<li>
 							  <def>Stun</def>
-							  <amount>7.5</amount>
+							  <amount>8</amount>
 							</li>
 						</secondaryDamage>
 					</projectile>
@@ -247,7 +247,7 @@
 						<secondaryDamage>
 							<li>
 							  <def>Stun</def>
-							  <amount>7.5</amount>
+							  <amount>8</amount>
 							</li>
 						</secondaryDamage>
 					</projectile>
@@ -267,7 +267,7 @@
 						<secondaryDamage>
 							<li>
 							  <def>Stun</def>
-							  <amount>7.5</amount>
+							  <amount>8</amount>
 							</li>
 						</secondaryDamage>
 					</projectile>
@@ -287,7 +287,7 @@
 						<secondaryDamage>
 							<li>
 							  <def>Stun</def>
-							  <amount>7.5</amount>
+							  <amount>8</amount>
 							</li>
 						</secondaryDamage>
 					</projectile>

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
@@ -89,9 +89,9 @@
 			  <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
 			  <warmupTime>0.15</warmupTime>
 			  <range>16</range>
-			  <ticksBetweenBurstShots>0.5</ticksBetweenBurstShots>
+			  <ticksBetweenBurstShots>1</ticksBetweenBurstShots>
 			  <burstShotCount>5</burstShotCount>
-			  <soundCast>HissFlamethrower</soundCast>
+			  <soundCast>ThrowMolotovCocktail</soundCast>
 			  <muzzleFlashScale>2</muzzleFlashScale>
 				<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 			</Properties>


### PR DESCRIPTION
## Additions

None

## Changes

Changing float values to int in order to remove console warnings,
Restoring incorrect (outdated?) sound to default.

## Reasoning

Removing Console Spam.

## Testing

- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded